### PR TITLE
Native sharesheet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.DS_Store
+*.xcuserstate
+*xcschememanagement.plist

--- a/sharegpt-extension/index.js
+++ b/sharegpt-extension/index.js
@@ -68,7 +68,20 @@ function init() {
     const { id } = await res.json();
     const url = `https://shareg.pt/${id}`;
 
-    window.open(url, "_blank");
+    const shareData = {
+      title: 'ShareGPT',
+      text: 'Shared ChatGPT Conversation',
+      url: url,
+    }
+    if (navigator.canShare(shareData)) {
+      navigator.share(shareData);
+    }
+    else {
+      const popUpOpened = window.open(url, "_blank");
+      if (popUpOpened == null || typeof (popUpOpened) == 'undefined') {
+        alert('ShareGPT: popup blocked :(');
+      }
+    }
 
     setTimeout(() => {
       shareButton.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-3 h-3">


### PR DESCRIPTION
Use native share sheet instead of opening a popup.

Fallback to popup if browser reports share sheet cannot be used. 

If popup fails, show `alert()`.