### PR TITLE
replace "sharegpt-app" with "app" in app/README.md

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -9,14 +9,14 @@ Frontend for ChatGPT Share. To start sharing ChatGPT conversations, visit https:
 
 ```bash
     export DATABASE_URL="mysql://user:password@host:port/database"
-    npx prisma migrate dev --schema sharegpt-app/prisma/schema.prisma
+    npx prisma migrate dev --schema app/prisma/schema.prisma
 ```
 
 3. Copy the .env.example file to .env and fill in the values
-4. Install dependencies in the sharegpt-app
+4. Install dependencies in the app
 
 ```bash
-cd sharegpt-app
+cd app
 yarn
 ```
 


### PR DESCRIPTION
I found the previous directory name was used in the command.
````diff
  ```bash
      export DATABASE_URL="mysql://user:password@host:port/database"
-      npx prisma migrate dev --schema sharegpt-app/prisma/schema.prisma
+      npx prisma migrate dev --schema app/prisma/schema.prisma
  ```

  3. Copy the .env.example file to .env and fill in the values
- 4. Install dependencies in the sharegpt-app
+ 4. Install dependencies in the app

  ```bash
- cd sharegpt-app
+ cd app
  yarn
  ```
````